### PR TITLE
removing the Twitter.com

### DIFF
--- a/data/kowabit.de-kwbtlist/list.txt
+++ b/data/kowabit.de-kwbtlist/list.txt
@@ -6937,7 +6937,7 @@ tvtv.bg
 tvysoftware.com
 tw.adsonar.com
 twitpic.com
-twitter.com
+
 twittweb.com
 twyn.com
 tx2.ru


### PR DESCRIPTION
"Twitter.com" is a trustworthy domain. So please remove it.